### PR TITLE
FIX: "Host key verification failed" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The client runs quietly as a service in the background.
     sudo apt update && sudo apt upgrade
     sudo apt install openssh-client sshpass ca-certificates curl unattended-upgrades $additional_packages -y
     nano studnet.sh
-    <edit studnet_nr, studnet_nr, known_hosts_filepath, and identity_file_filepath then save changes by ctrl-s then ctrl-x >
+    <edit studnet_nr, studnet_nr, and known_hosts_filepath then save changes by ctrl-s then ctrl-x >
     sudo cp studnet.sh /usr/local/bin/studnet.sh
     sudo chmod u+rwx /usr/local/bin/studnet.sh
     sudo cp studnet.service /etc/systemd/system/studnet.service

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The client runs quietly as a service in the background.
     sudo apt update && sudo apt upgrade
     sudo apt install openssh-client sshpass ca-certificates curl unattended-upgrades $additional_packages -y
     nano studnet.sh
-    <edit studnet_nr and studnet_nr and save changes by ctrl-s then ctrl-x >
+    <edit studnet_nr, studnet_nr, known_hosts_filepath, and identity_file_filepath then save changes by ctrl-s then ctrl-x >
     sudo cp studnet.sh /usr/local/bin/studnet.sh
     sudo chmod u+rwx /usr/local/bin/studnet.sh
     sudo cp studnet.service /etc/systemd/system/studnet.service

--- a/studnet.sh
+++ b/studnet.sh
@@ -3,7 +3,6 @@ studnet_nr=""
 studnet_password=""
 studnet_server_ip="139.18.143.253"
 known_hosts_filepath="/home/USERNAME/.ssh/known_hosts"
-identity_file_filepath="/home/USERNAME/.ssh/id_rsa"
 host=https://google.de
 
 while true; do
@@ -26,7 +25,6 @@ while true; do
       ssh \
       -tt \
       -o "UserKnowHostsFile=$known_hosts_filepath" \
-      -o "IdentityFile=$identity_file_filepath" \
       -o "ServerAliveInterval 15" \
       -o "ServerAliveCountMax 2" \
       -o "ConnectTimeout 10" \

--- a/studnet.sh
+++ b/studnet.sh
@@ -2,6 +2,8 @@
 studnet_nr=""
 studnet_password=""
 studnet_server_ip="139.18.143.253"
+known_hosts_filepath="/home/USERNAME/.ssh/known_hosts"
+identity_file_filepath="/home/USERNAME/.ssh/id_rsa"
 host=https://google.de
 
 while true; do
@@ -23,6 +25,8 @@ while true; do
       -p "$studnet_password" \
       ssh \
       -tt \
+      -o "UserKnowHostsFile=$known_hosts_filepath" \
+      -o "IdentityFile=$identity_file_filepath" \
       -o "ServerAliveInterval 15" \
       -o "ServerAliveCountMax 2" \
       -o "ConnectTimeout 10" \


### PR DESCRIPTION
I had my raspberryPi throw the error "Host key verification failed"  even though 139.18.143.253 key is in known_hosts and the permissions were given as asked in the readme.
Explicitly stating the file path for the known_hosts and identity_file fixed the issue.
I added corresponding lines to the studnet.sh and the readme.md. 

Thanks for this cool project. Works like a charm now.